### PR TITLE
Update Sylvan benchmark.

### DIFF
--- a/Excel_PRIME.Bench/AccessEveryCellBenchmarks.cs
+++ b/Excel_PRIME.Bench/AccessEveryCellBenchmarks.cs
@@ -30,21 +30,30 @@ public class AccessEveryCellBenchmarks
     public string FileName { get; set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
+    
+    static ExcelDataReaderOptions ErrorsAsString = 
+        new ExcelDataReaderOptions { 
+            // formula errors read as their string values
+            FormulaErrorHandling = FormulaErrorHandling.String 
+        };
+
     [Benchmark(Baseline = true)]
     [MethodImpl(MethodImplOptions.NoOptimization)]
     public async Task<int> SylvanRdr()
     {
         int cells = 0;
-        // ReSharper disable once MethodHasAsyncOverload
-        using ExcelDataReader reader = ExcelDataReader.Create(RootFolder + FileName);
-        //using ExcelDataReader reader = await ExcelDataReader.CreateAsync(RootFolder + FileName).ConfigureAwait(true);
+        using ExcelDataReader reader = await ExcelDataReader.CreateAsync(RootFolder + FileName, ErrorsAsString).ConfigureAwait(true);
         do
         {
+            // include the headers in the populated cell count
+            cells += reader.FieldCount;
             while (await reader.ReadAsync().ConfigureAwait(true))
             {
                 for (int ordinal = 0; ordinal < reader.RowFieldCount; ordinal++)
                 {
-                    if (!string.IsNullOrEmpty(reader.GetExcelValue(ordinal).ToString()))
+                    // this also passes the unit test, and is much more efficient
+                    //if (!reader.IsDBNull(ordinal)) 
+                    if (!string.IsNullOrEmpty(reader.GetString(ordinal)))
                     {
                         cells++;
                     }

--- a/Excel_PRIME.Bench/Excel_PRIME.Bench.csproj
+++ b/Excel_PRIME.Bench/Excel_PRIME.Bench.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
 		<PackageReference Include="FastExcel" Version="3.0.13" />
 		<PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.7.37220.1" />
-		<PackageReference Include="Sylvan.Data.Excel" Version="0.5.5" />
+		<PackageReference Include="Sylvan.Data.Excel" Version="0.5.6" />
 		<PackageReference Include="XlsxHelper" Version="2.1.0" />
 	</ItemGroup>
 

--- a/Excel_PRIME.Tests/PerformanceTesting.cs
+++ b/Excel_PRIME.Tests/PerformanceTesting.cs
@@ -13,82 +13,68 @@ namespace ExcelPRIME.Tests;
 
 [ExcludeFromCodeCoverage]
 [TestFixture]
+[Explicit("Lot of data being thrown about !")]
 internal class PerformanceTesting
 {
+    static readonly object[] TestCases =
+        new object[] {
+            new object[] {"sampledocs-50mb-xlsx-file", 7000012 },
+            new object[] {"Blank Data 1 Million Rows", 15463982 },
+            new object[] {"sampledocs-50mb-xlsx-file-sst", 7000012 },
+            new object[] {"100mb", 8930256 }
+        };
+
     [Test]
-    [TestCase("sampledocs-50mb-xlsx-file.xlsx", 7000012)]
-    [TestCase("Blank Data 1 Million Rows.xlsx", 15463982)]
-    [TestCase("sampledocs-50mb-xlsx-file-sst.xlsx", 7000012)]
-    [TestCase("100mb.xlsx", 8930256)]
-    [Explicit("Lot of data being thrown about !")]
+    [TestCaseSource(nameof(TestCases))]
     public void A010_AccessEveryCellExcel_Prime(string fileName, int expectedCells)
     {
-        AccessEveryCellBenchmarks aecB = new() { FileName = fileName };
+        AccessEveryCellBenchmarks aecB = new() { FileName = fileName + ".xlsx" };
         int cells = aecB.Excel_Prime();
         cells.Should().Be(expectedCells);
     }
 
     [Test]
-    [TestCase("sampledocs-50mb-xlsx-file.xlsb", 7000012)]
-    [TestCase("Blank Data 1 Million Rows.xlsb", 15463982)]
-    [TestCase("sampledocs-50mb-xlsx-file-sst.xlsb", 7000012)]
-    [TestCase("100mb.xlsb", 8930256)]
-    [Explicit("Lot of data being thrown about !")]
+    [TestCaseSource(nameof(TestCases))]
     public void A011_AccessEveryCellExcel_Prime_Xlsb(string fileName, int expectedCells)
     {
-        AccessEveryCellBenchmarksXlsb aecB = new() { FileName = fileName };
+        AccessEveryCellBenchmarksXlsb aecB = new() { FileName = fileName + ".xlsb" };
         int cells = aecB.Excel_PrimeXlsb();
         cells.Should().Be(expectedCells);
     }
 
     [Test]
-    [TestCase("sampledocs-50mb-xlsx-file.xlsx", 7000014)]
-    [TestCase("Blank Data 1 Million Rows.xlsx", 25601276)]
-    [TestCase("sampledocs-50mb-xlsx-file-sst.xlsx", 7000014)]
-    [TestCase("100mb.xlsx", 8935680)]
-    [Explicit("Lot of data being thrown about !")]
+    [TestCaseSource(nameof(TestCases))]
     public void A020_AccessEveryCellXlsxHelper(string fileName, int expectedCells)
     {
-        AccessEveryCellBenchmarks aecB = new() { FileName = fileName };
+        AccessEveryCellBenchmarks aecB = new() { FileName = fileName + ".xlsx" };
         int cells = aecB.XlsxHelper();
-        cells.Should().BeGreaterThan(expectedCells);
+        cells.Should().Be(expectedCells);
     }
 
     [Test]
-    [TestCase("sampledocs-50mb-xlsx-file.xlsx", 7000014)]
-    [TestCase("Blank Data 1 Million Rows.xlsx", 25601276)]
-    [TestCase("sampledocs-50mb-xlsx-file-sst.xlsx", 7000014)]
-    [TestCase("100mb.xlsx", 8935680)]
-    [Explicit("Lot of data being thrown about !")]
+    [TestCaseSource(nameof(TestCases))]
     public async Task A030_AccessEveryCellSylvan(string fileName, int expectedCells)
     {
-        AccessEveryCellBenchmarks aecB = new() { FileName = fileName };
+        AccessEveryCellBenchmarks aecB = new() { FileName = fileName + ".xlsx" };
         int cells = await aecB.SylvanRdr().ConfigureAwait(false);
-        cells.Should().BeGreaterThan(expectedCells);
+        cells.Should().Be(expectedCells);
     }
 
+
     //[Test]
-    //[TestCase("sampledocs-50mb-xlsx-file.xlsx", 7000014)]
-    //[TestCase("Blank Data 1 Million Rows.xlsx", 25601276)]
-    //[TestCase("sampledocs-50mb-xlsx-file-sst.xlsx", 7000014)]
-    //[TestCase("100mb.xlsx", 8935680)]
-    //[Explicit("Lot of data being thrown about !")]
+    //[TestCaseSource(nameof(TestCases))]
     //public void A040_AccessEveryCellFastExcel(string fileName, int expectedCells)
     //{
-    //    AccessEveryCellBenchmarks aecB = new AccessEveryCellBenchmarks { FileName = fileName };
+    //    AccessEveryCellBenchmarks aecB = new AccessEveryCellBenchmarks { FileName = fileName + ".xlsx" };
     //    int cells = aecB.FastExcel();
     //    cells.Should().Be(expectedCells);
     //}
 
     [Test]
-    [TestCase("sampledocs-50mb-xlsx-file.xlsx", 7000012)]
-    [TestCase("Blank Data 1 Million Rows.xlsx", 15463982)]
-    [TestCase("sampledocs-50mb-xlsx-file-sst.xlsx", 7000012)]
-    [TestCase("100mb.xlsx", 8930256)]
-    [Explicit("Lot of data being thrown about !")]
+    [TestCaseSource(nameof(TestCases))]
     public async Task A040_ParallelEveryCellAsyncExcel_PrimeTwice(string fileName, int expectedCells)
     {
-        AccessEveryCellBenchmarks aecB = new() { FileName = fileName };
+        AccessEveryCellBenchmarks aecB = new() { FileName = fileName + ".xlsx" };
         int cells = await aecB.PrlAsyncExcel_PrimeTwice().ConfigureAwait(false);
         cells.Should().Be(expectedCells);
     }


### PR DESCRIPTION
I was reviewing your benchmarks and the associated tests and I was surprised by your use of `GetExcelValue`, when I'd expect that `GetString` would serve the same purpose, but more efficiently. `GetExcelValue` returns the underlying excel data type, but it boxes any value types. I see the reason you might have done this though, since the pattern of `GetExcelValue(i).Tostring()` would also return formula errors as strings, where the default behavior would throw an exception if you called `GetString`. I've added an option to read formula errors as their string representation, since that's what your test was expecting. This could have been achieved without a change to my library, but the code would have been more complex.

I also tweaked the tests. The different performance tests didn't previously agree on the number of populated cells in each file, and I'd hope that all our libraries could at least agree on that.

I've also left in a commented out-line of `if (!reader.IsDBNull(ordinal))` in my benchmark, which also passes the unit test and is much more efficient than calling `GetString`, as it doesn't create a new string. I left it with the original implementation though, since that's more in the spirit of the competing benchmarks.